### PR TITLE
Added filter type, for interfaces

### DIFF
--- a/Editor/PickleAttributeDrawer.cs
+++ b/Editor/PickleAttributeDrawer.cs
@@ -4,6 +4,7 @@ using UnityEditor;
 using UnityEngine;
 using Pickle.ObjectProviders;
 using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace Pickle.Editor
 {
@@ -59,7 +60,11 @@ namespace Pickle.Editor
                 {
                     if (attribute.FilterType != null)
                     {
-                        _filter = pair => (pair.Object as Component)?.GetComponent(attribute.FilterType);
+                        _filter = pair =>
+                        {
+                            Type componentType = pair.Object.GetType();
+                            return attribute.FilterType.IsAssignableFrom(componentType);
+                        };
                     }
                     
                     objectProvider = attribute.LookupType.ResolveProviderTypeToProvider(_fieldType, targetObject);

--- a/Editor/PickleAttributeDrawer.cs
+++ b/Editor/PickleAttributeDrawer.cs
@@ -51,11 +51,17 @@ namespace Pickle.Editor
                 _filter = null;
 
                 var attribute = (PickleAttribute)this.attribute;
+
                 IObjectProvider objectProvider;
                 PickerType pickerType = PickleSettings.GetDefaultPickerType(_fieldType);
 
                 if (base.attribute != null)
                 {
+                    if (attribute.FilterType != null)
+                    {
+                        _filter = pair => (pair.Object as Component)?.GetComponent(attribute.FilterType);
+                    }
+                    
                     objectProvider = attribute.LookupType.ResolveProviderTypeToProvider(_fieldType, targetObject);
 
                     if (!string.IsNullOrEmpty(attribute.FilterMethodName))

--- a/Editor/PickleAttributeDrawer.cs
+++ b/Editor/PickleAttributeDrawer.cs
@@ -4,7 +4,6 @@ using UnityEditor;
 using UnityEngine;
 using Pickle.ObjectProviders;
 using System.Collections;
-using System.Runtime.CompilerServices;
 
 namespace Pickle.Editor
 {

--- a/Runtime/PickleAttribute.cs
+++ b/Runtime/PickleAttribute.cs
@@ -11,6 +11,7 @@ namespace Pickle
         public PickerType PickerType = PickerType.Dropdown;
         public string FilterMethodName = null;
         public AutoPickMode AutoPickMode = AutoPickMode.None;
+        public Type FilterType = null;
     }
 
     public enum PickerType


### PR DESCRIPTION
Simple inclusion of filtering for interfaces.
Using the FilterMethod will still override this behaviour. So for now it's just a simple fix.
Not sure if there is a proper replacement for the GetComponent call.