### PR TITLE
Fixed a bug that prevented GameObjects from being dropped when using custom filters.

### DIFF
--- a/Editor/ObjectFieldDrawer.cs
+++ b/Editor/ObjectFieldDrawer.cs
@@ -136,6 +136,16 @@ namespace Pickle.Editor
             if (draggedObjects.Length != 1) return null;
             var obj = draggedObjects[0];
 
+            if (obj is GameObject gameObject)
+            {
+                foreach (var item in gameObject.GetComponents<Component>())
+                {
+                    if (IsObjectValidForField.Invoke(item))
+                        return item;
+                }
+                return null;
+            }
+
             return IsObjectValidForField.Invoke(obj) ? obj : null;
         }
 

--- a/Editor/ObjectFieldDrawer.cs
+++ b/Editor/ObjectFieldDrawer.cs
@@ -149,8 +149,10 @@ namespace Pickle.Editor
             return IsObjectValidForField.Invoke(obj) ? obj : null;
         }
 
-        private static bool HandleDragEvents(bool isValidObjectBeingDragged, ref UnityEngine.Object activeObject)
+        private static bool HandleDragEvents(UnityEngine.Object validObjectBeingDragged, ref UnityEngine.Object activeObject)
         {
+            bool isValidObjectBeingDragged = validObjectBeingDragged;
+
             var ev = Event.current;
             if (ev.type == EventType.DragUpdated)
             {
@@ -170,7 +172,7 @@ namespace Pickle.Editor
                 if (isValidObjectBeingDragged)
                 {
                     DragAndDrop.AcceptDrag();
-                    activeObject = DragAndDrop.objectReferences[0];
+                    activeObject = validObjectBeingDragged;
                 }
 
                 return true;


### PR DESCRIPTION
This is a fixed version of #6 